### PR TITLE
Fixed DjDT URL reversal

### DIFF
--- a/fourtyone/settings.py
+++ b/fourtyone/settings.py
@@ -222,3 +222,5 @@ try:
 except ImportError as exp:
     pass
 
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+

--- a/fourtyone/urls.py
+++ b/fourtyone/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include, url, patterns
 from django.conf.urls.static import static
 from django.views.generic import TemplateView
 
@@ -15,3 +15,9 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += patterns('',
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )


### PR DESCRIPTION
Getting an error `u'djdt' is not a registered namespace`, probably from some earlier PR. The `django-debug-toolbar` package wasn't properly configured, so this PR fixes that.
